### PR TITLE
fix deprecation warning

### DIFF
--- a/DependencyInjection/FormatzPhoneNumberExtension.php
+++ b/DependencyInjection/FormatzPhoneNumberExtension.php
@@ -17,12 +17,12 @@ class FormatzPhoneNumberExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
-        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.xml');
     }
 }


### PR DESCRIPTION
Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Formatz\Bundle\PhoneNumberBundle\DependencyInjection\FormatzPhoneNumberExtension" now to avoid errors or add an explicit @return annotation to suppress this message.